### PR TITLE
feat: use Ultramarine logo in Xfce panel

### DIFF
--- a/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -76,6 +76,7 @@
       </property>
       <property name="button-single-row" type="bool" value="false"/>
       <property name="show-button-title" type="bool" value="true"/>
+      <property name="button-icon" type="string" value="/usr/share/icons/Bluecurve/22x22/apps/start-here.png"/>
     </property>
     <property name="plugin-8" type="string" value="pulseaudio">
       <property name="enable-keyboard-shortcuts" type="bool" value="true"/>


### PR DESCRIPTION
What this does:

<img width="461" height="444" alt="image" src="https://github.com/user-attachments/assets/7fadc9ec-da41-459d-b042-4edac85b6aba" />
